### PR TITLE
change so that the search keyword is case sensitive

### DIFF
--- a/IsBanken.Buisness/Infrastructure/CustomerHandler.cs
+++ b/IsBanken.Buisness/Infrastructure/CustomerHandler.cs
@@ -37,7 +37,9 @@ namespace IsBanken.Buisness.Infrastructure
 
         public Dictionary<int, string> CustomerSearchByNameOrCity(string term)
         {
-            var result = Context.Customers.Where(c => c.CompanyName.ToLower().Contains(term) || c.City.ToLower().Contains(term)).ToList();
+            var termToLower = term.ToLower();
+
+            var result = Context.Customers.Where(c => c.CompanyName.ToLower().Contains(termToLower) || c.City.ToLower().Contains(termToLower)).ToList();
 
             var dictionary = result.ToDictionary(c => c.CustomerId, c => c.CompanyName);
 

--- a/IsBanken.Buisness/Infrastructure/CustomerHandler.cs
+++ b/IsBanken.Buisness/Infrastructure/CustomerHandler.cs
@@ -37,7 +37,7 @@ namespace IsBanken.Buisness.Infrastructure
 
         public Dictionary<int, string> CustomerSearchByNameOrCity(string term)
         {
-            var result = Context.Customers.Where(c => c.CompanyName.Contains(term) || c.City.Contains(term)).ToList();
+            var result = Context.Customers.Where(c => c.CompanyName.ToLower().Contains(term) || c.City.ToLower().Contains(term)).ToList();
 
             var dictionary = result.ToDictionary(c => c.CustomerId, c => c.CompanyName);
 

--- a/IsBanken.ConsoleApp/Program.cs
+++ b/IsBanken.ConsoleApp/Program.cs
@@ -299,7 +299,7 @@ namespace IsBanken.ConsoleApp
             Console.WriteLine("* Sök kund *");
             Console.Write("Ange namn eller postort: ");
 
-            var term = Console.ReadLine();
+            var term = Console.ReadLine().ToLower();
             var result = _bank.CustomerSearch(term);
 
             if (result.Count > 0)

--- a/IsBanken.ConsoleApp/Program.cs
+++ b/IsBanken.ConsoleApp/Program.cs
@@ -331,7 +331,7 @@ namespace IsBanken.ConsoleApp
             Console.WriteLine("* Sök kund *");
             Console.Write("Ange namn eller postort: ");
 
-            var term = Console.ReadLine().ToLower();
+            var term = Console.ReadLine();
             Console.WriteLine();
 
             var result = _bank.CustomerSearch(term);

--- a/IsBanken.Tests/UnitTests.cs
+++ b/IsBanken.Tests/UnitTests.cs
@@ -76,10 +76,13 @@ namespace IsBanken.Tests
         [Fact]
         public void Test_search_customer_by_name_or_city()
         {
-            var searchterm = "Ice";
-            var customer = _bank.CustomerSearch(searchterm);
+            var searchCapitalLetter = "Ice";
+            var searchLowerLetter = "ice";
 
-            Assert.Equal(1, customer.Count);
+            var customerCapital = _bank.CustomerSearch(searchCapitalLetter);
+            var customerLower = _bank.CustomerSearch(searchLowerLetter);
+
+            Assert.Equal(customerCapital.Count, customerLower.Count);
         }
 
         [Fact]


### PR DESCRIPTION
När man söker på ett kundnamn eller ort så va det case sensetive. Efter fixen kan man nu skriva hur man vill så länge stavningen är rätt